### PR TITLE
chore: remove github MCP server config

### DIFF
--- a/claude/.claude.json
+++ b/claude/.claude.json
@@ -24,13 +24,6 @@
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer $(grep GITHUB_PAT ~/Documents/personal/dotfiles/.env | cut -d '=' -f2)"
-      }
-    },
     "chrome-devtools": {
       "command": "npx",
       "args": [


### PR DESCRIPTION
## Summary
- Remove the GitHub Copilot MCP server entry from `claude/.claude.json`

## Test plan
- [x] Verify Claude Code starts without errors after removing the config
- [x] Confirm other MCP servers (context7, chrome-devtools, etc.) still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration by removing an MCP server entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->