### PR TITLE
feat(nix): Phase 1 — home-manager + zsh passthrough + CLI packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777086106,
+        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -38,6 +58,7 @@
     },
     "root": {
       "inputs": {
+        "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,14 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = inputs @ { self, nixpkgs, nix-darwin }:
+  outputs = inputs @ { self, nixpkgs, nix-darwin, home-manager }:
     let
       forAllSystems = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-darwin" ];
       mkHost = import ./lib/mkHost.nix;

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,0 +1,14 @@
+{ username, ... }:
+
+{
+  imports = [
+    ./packages.nix
+    ./programs/zsh.nix
+  ];
+
+  home.username = username;
+  home.homeDirectory = "/Users/${username}";
+  home.stateVersion = "25.11";
+
+  programs.home-manager.enable = true;
+}

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+{
+  # Phase 1: CLI tools only. Runtimes (node/python/go/rust/bun/etc.) move
+  # off mise into nix in Phase 4.
+  home.packages = with pkgs; [
+    direnv
+    fd
+    gh
+    ghq
+    gnupg
+    jq
+    lua
+    prettierd
+    ripgrep
+    tree-sitter
+  ];
+}

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -4,7 +4,6 @@
   # Phase 1: CLI tools only. Runtimes (node/python/go/rust/bun/etc.) move
   # off mise into nix in Phase 4.
   home.packages = with pkgs; [
-    direnv
     fd
     gh
     ghq

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -10,7 +10,6 @@
     gnupg
     jq
     lua
-    pinentry_mac
     prettierd
     ripgrep
     tree-sitter

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -10,6 +10,7 @@
     gnupg
     jq
     lua
+    pinentry_mac
     prettierd
     ripgrep
     tree-sitter

--- a/home/programs/zsh.nix
+++ b/home/programs/zsh.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs.zsh = {
+    enable = true;
+
+    # Phase 1 minimal: source the legacy ~/.zshrc.backup created on first
+    # home-manager activation so existing shell behavior (Homebrew PATH,
+    # mise, fzf widgets, prompt, completions) is preserved unchanged.
+    # Phase 4 cleans this up and migrates the body into Nix.
+    initContent = ''
+      if [ -f "$HOME/.zshrc.backup" ]; then
+        source "$HOME/.zshrc.backup"
+      fi
+    '';
+  };
+}

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -5,5 +5,15 @@ inputs.nix-darwin.lib.darwinSystem {
   specialArgs = { inherit inputs hostName username system; };
   modules = [
     ../darwin
+    inputs.home-manager.darwinModules.home-manager
+    {
+      home-manager = {
+        useGlobalPkgs = true;
+        useUserPackages = true;
+        backupFileExtension = "backup";
+        extraSpecialArgs = { inherit inputs username; };
+        users.${username} = import ../home;
+      };
+    }
   ];
 }


### PR DESCRIPTION
## Summary

Phase 1 of the **nix-darwin + home-manager** migration. Wires home-manager into the existing `mihiro-mac` darwin configuration without changing the user's interactive shell behavior, and starts moving CLI tools off Homebrew.

Builds on the Phase 0 skeleton merged in #10. `git.nix` is **intentionally deferred to Phase 2** to avoid migrating `~/.config/git/config` (FZF aliases, conditional includes, LFS filters) without a verification pass.

### Phase 1 has exactly three goals

1. **Stand up the home-manager pipeline** — from now on `darwin-rebuild switch` reconciles both system and user-home in one go.
2. **Migrate a small slice of CLI tools off Homebrew** — proves the nix CLI workflow before Phase 3/4 do the bulk move.
3. **Preserve the existing zsh experience verbatim** — first activation renames `~/.zshrc` → `~/.zshrc.backup`, the new managed `~/.zshrc` just re-sources it. Mise / anyenv / kitty hooks / fzf bindings keep working unchanged. Phase 4 cleans the body up.

### Changes

- `flake.nix` — `home-manager` input added (`follows = "nixpkgs"`).
- `lib/mkHost.nix` — registers `home-manager.darwinModules.home-manager` with `useGlobalPkgs`, `useUserPackages`, `backupFileExtension = "backup"`, and imports `../home` for the user.
- `home/default.nix` — `home.username` / `home.homeDirectory` / `home.stateVersion = "25.11"` / `programs.home-manager.enable`.
- `home/programs/zsh.nix` — `programs.zsh.enable` + `initContent` that sources `~/.zshrc.backup`.
- `home/packages.nix` — CLI tools migrating from Homebrew: `ripgrep fd gh ghq prettierd gnupg lua jq tree-sitter`. Runtimes (node/python/go/rust/bun/etc.) stay on mise until Phase 4.

### Brew uninstall after activation

Once `darwin-rebuild switch` succeeds, the following brew formulae are duplicated by nix and should be removed so PATH lookups land in `~/.nix-profile/bin`:

```
brew uninstall ripgrep fd gh ghq prettierd gpg lua jq tree-sitter
# leave installed for now: git fzf nvim mise tmux  (Phase 2 / 4 will replace these)
```

`gnupg` in nix maps to the `gpg` binary, hence `brew uninstall gpg`.

### Out of scope (next phases)

- `git.nix` (Phase 2) — needs the values from `~/.config/git/config` (already received).
- `programs.fzf` / `programs.tmux` / `programs.gh` modules (Phase 2).
- `programs.direnv` + `nix-direnv` — added later if/when project-specific runtime overrides become a need; current `mise` config has every tool pinned to `latest` (purely global), so direnv has no payoff yet.
- Homebrew cask migration to nix-darwin homebrew module (Phase 3).
- mise → nix runtimes + `.zshrc` cleanup (Phase 4).

## Test plan

On the target Mac (after `git pull` of this branch):

- [x] `nix flake check` passes.
- [x] `nix run nix-darwin -- build --flake .#mihiro-mac` produces `./result` without errors.
- [x] `sudo darwin-rebuild switch --flake .#mihiro-mac` activates.
- [x] `~/.zshrc.backup` exists and contains the previous ~/.zshrc content.
- [x] `readlink ~/.zshrc` points into `/nix/store/...-home-manager-files/.zshrc` (or similar).
- [x] A new shell still shows the old prompt, mise activation works, fzf widgets (Ctrl-r/g/v/o) still bound, kitty tab title hook still runs.
- [ ] `which rg fd gh ghq prettierd jq lua tree-sitter gpg` all resolve under `~/.nix-profile/bin/` (or `/etc/profiles/per-user/mihiro/bin/`).
- [ ] After `brew uninstall ripgrep fd gh ghq prettierd gpg lua jq tree-sitter`, the same `which` checks still succeed and CLI tools work as expected.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Home Manager integration for managing user environment configuration
  * Integrated Zsh shell configuration support with backward compatibility for existing settings

* **Chores**
  * Added CLI utilities to the system environment (fd, GitHub CLI, gnupg, jq, lua, ripgrep, tree-sitter)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->