### PR TITLE
feat(nix): Phase 2 — git, fzf, gh, tmux, gpg-agent home-manager modules

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -3,6 +3,11 @@
 {
   imports = [
     ./packages.nix
+    ./programs/fzf.nix
+    ./programs/gh.nix
+    ./programs/git.nix
+    ./programs/gpg.nix
+    ./programs/tmux.nix
     ./programs/zsh.nix
   ];
 

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -5,7 +5,6 @@
   # off mise into nix in Phase 4.
   home.packages = with pkgs; [
     fd
-    gh
     ghq
     gnupg
     jq

--- a/home/programs/fzf.nix
+++ b/home/programs/fzf.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+    defaultOptions = [
+      "--layout=reverse"
+      "--border"
+      "--color=fg:#5c6a72,bg:#fdf6e3,hl:#35a77c"
+      "--color=fg+:#5c6a72,bg+:#eaedc8,hl+:#35a77c"
+      "--color=info:#8da101,prompt:#5c6a72,pointer:#35a77c"
+      "--color=marker:#f85552,spinner:#df69ba,header:#8da101"
+    ];
+  };
+}

--- a/home/programs/gh.nix
+++ b/home/programs/gh.nix
@@ -1,0 +1,5 @@
+{ ... }:
+
+{
+  programs.gh.enable = true;
+}

--- a/home/programs/git.nix
+++ b/home/programs/git.nix
@@ -4,12 +4,17 @@
   programs.git = {
     enable = true;
 
-    userName = "MihiroH";
-    userEmail = "mihiro.hashimoto.1125@gmail.com";
-
     lfs.enable = true;
 
-    extraConfig = {
+    settings = {
+      user = {
+        name = "MihiroH";
+        email = "mihiro.hashimoto.1125@gmail.com";
+
+        # Custom user.mail field used by some downstream tooling.
+        mail = "mihiro.hashimoto.1125@gmail.com";
+      };
+
       core = {
         excludesFile = "~/.config/git/ignore";
         editor = "nvim";
@@ -30,8 +35,32 @@
 
       phantom.ai = "claude";
 
-      # Custom user.mail field used by some downstream tooling.
-      "user".mail = "mihiro.hashimoto.1125@gmail.com";
+      alias = {
+        b = "branch";
+        c = "commit";
+        cm = "commit -m";
+        f = "fetch";
+        s = "status";
+        st = "stash";
+        rh = "reset --hard";
+
+        co = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git checkout $(echo $branch | sed 's#remotes/[^/]*/##'); else git checkout $args; fi }; f'';
+
+        reb = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git rebase $(echo $branch | sed 's#remotes/[^/]*/##'); fi }; f'';
+
+        mer = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git merge $(echo $branch | sed 's#remotes/[^/]*/##'); fi }; f'';
+
+        d = ''!f() { args=$@; [ -z "$args" ] && args=HEAD; ([ "$args" = "HEAD" ] && git status --short || git diff --name-status $args | sed 's/\t/  /') | fzf --preview "echo {} | cut -c 4- | xargs git diff --color=always $args --" --multi --height 90% | cut -c 4-; }; f'';
+
+        stl = ''!git stash list | fzf --preview 'echo {} | cut -d":" -f1 | xargs git stash show -p --color=always' --height 90% | cut -d':' -f1'';
+
+        stp = "!git stl | xargs git stash pop";
+        std = "!git stl | xargs git stash drop";
+
+        "delete-merged-branch" = ''!f() { git fetch -p; for branch in $(git branch -vv | grep ": gone]" | awk '{print $1}'); do git branch -D "$branch"; done; }; f'';
+
+        parent = ''!git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//' #'';
+      };
     };
 
     includes = [
@@ -40,32 +69,5 @@
         path = "~/.gitconfig-personal";
       }
     ];
-
-    aliases = {
-      b = "branch";
-      c = "commit";
-      cm = "commit -m";
-      f = "fetch";
-      s = "status";
-      st = "stash";
-      rh = "reset --hard";
-
-      co = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git checkout $(echo $branch | sed 's#remotes/[^/]*/##'); else git checkout $args; fi }; f'';
-
-      reb = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git rebase $(echo $branch | sed 's#remotes/[^/]*/##'); fi }; f'';
-
-      mer = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git merge $(echo $branch | sed 's#remotes/[^/]*/##'); fi }; f'';
-
-      d = ''!f() { args=$@; [ -z "$args" ] && args=HEAD; ([ "$args" = "HEAD" ] && git status --short || git diff --name-status $args | sed 's/\t/  /') | fzf --preview "echo {} | cut -c 4- | xargs git diff --color=always $args --" --multi --height 90% | cut -c 4-; }; f'';
-
-      stl = ''!git stash list | fzf --preview 'echo {} | cut -d":" -f1 | xargs git stash show -p --color=always' --height 90% | cut -d':' -f1'';
-
-      stp = "!git stl | xargs git stash pop";
-      std = "!git stl | xargs git stash drop";
-
-      "delete-merged-branch" = ''!f() { git fetch -p; for branch in $(git branch -vv | grep ": gone]" | awk '{print $1}'); do git branch -D "$branch"; done; }; f'';
-
-      parent = ''!git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//' #'';
-    };
   };
 }

--- a/home/programs/git.nix
+++ b/home/programs/git.nix
@@ -1,0 +1,71 @@
+{ ... }:
+
+{
+  programs.git = {
+    enable = true;
+
+    userName = "MihiroH";
+    userEmail = "mihiro.hashimoto.1125@gmail.com";
+
+    lfs.enable = true;
+
+    extraConfig = {
+      core = {
+        excludesFile = "~/.config/git/ignore";
+        editor = "nvim";
+      };
+
+      ghq.root = "~/Documents";
+
+      commit.template = "~/.stCommitMsg";
+
+      http.postBuffer = 1048576000;
+
+      push = {
+        default = "current";
+        autoSetupRemote = true;
+      };
+
+      pull.rebase = false;
+
+      phantom.ai = "claude";
+
+      # Custom user.mail field used by some downstream tooling.
+      "user".mail = "mihiro.hashimoto.1125@gmail.com";
+    };
+
+    includes = [
+      {
+        condition = "gitdir:~/Documents/personal/";
+        path = "~/.gitconfig-personal";
+      }
+    ];
+
+    aliases = {
+      b = "branch";
+      c = "commit";
+      cm = "commit -m";
+      f = "fetch";
+      s = "status";
+      st = "stash";
+      rh = "reset --hard";
+
+      co = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git checkout $(echo $branch | sed 's#remotes/[^/]*/##'); else git checkout $args; fi }; f'';
+
+      reb = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git rebase $(echo $branch | sed 's#remotes/[^/]*/##'); fi }; f'';
+
+      mer = ''!f() { args=$@; if [ -z "$args" ]; then branch=$(git branch --all | grep -v HEAD | fzf --preview 'echo {} | cut -c 3- | xargs git log --color=always' | cut -c 3-); git merge $(echo $branch | sed 's#remotes/[^/]*/##'); fi }; f'';
+
+      d = ''!f() { args=$@; [ -z "$args" ] && args=HEAD; ([ "$args" = "HEAD" ] && git status --short || git diff --name-status $args | sed 's/\t/  /') | fzf --preview "echo {} | cut -c 4- | xargs git diff --color=always $args --" --multi --height 90% | cut -c 4-; }; f'';
+
+      stl = ''!git stash list | fzf --preview 'echo {} | cut -d":" -f1 | xargs git stash show -p --color=always' --height 90% | cut -d':' -f1'';
+
+      stp = "!git stl | xargs git stash pop";
+      std = "!git stl | xargs git stash drop";
+
+      "delete-merged-branch" = ''!f() { git fetch -p; for branch in $(git branch -vv | grep ": gone]" | awk '{print $1}'); do git branch -D "$branch"; done; }; f'';
+
+      parent = ''!git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//' #'';
+    };
+  };
+}

--- a/home/programs/gpg.nix
+++ b/home/programs/gpg.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+{
+  # gnupg itself is provided via home/packages.nix. Wire pinentry-mac so
+  # gpg-agent uses the native macOS dialog when a passphrase is needed.
+  # Reference pkgs.pinentry_mac directly so its store path is realised
+  # without polluting PATH (the package installs only an .app bundle).
+  home.file.".gnupg/gpg-agent.conf".text = ''
+    pinentry-program ${pkgs.pinentry_mac}/Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac
+  '';
+}

--- a/home/programs/gpg.nix
+++ b/home/programs/gpg.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
   # gnupg itself is provided via home/packages.nix. Wire pinentry-mac so
@@ -7,5 +7,12 @@
   # without polluting PATH (the package installs only an .app bundle).
   home.file.".gnupg/gpg-agent.conf".text = ''
     pinentry-program ${pkgs.pinentry_mac}/Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac
+  '';
+
+  # Reload gpg-agent on switch so changes to gpg-agent.conf take effect
+  # without requiring a manual reloadagent or re-login. Tolerate the
+  # agent not being running (no signing happened yet this session).
+  home.activation.reloadGpgAgent = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.gnupg}/bin/gpg-connect-agent reloadagent /bye 2>/dev/null || true
   '';
 }

--- a/home/programs/tmux.nix
+++ b/home/programs/tmux.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.tmux ];
+
+  # Place at the XDG path the existing config's `bind r source-file
+  # ~/.config/tmux/tmux.conf` reload binding expects, instead of using
+  # programs.tmux which writes to ~/.tmux.conf.
+  xdg.configFile."tmux/tmux.conf".source = ../../tmux/tmux.conf;
+}


### PR DESCRIPTION
## Summary

Phase 2 of the **nix-darwin + home-manager** migration. Adds a slice of `programs.*` modules and migrates `~/.config/git/config` into `programs.git`. Builds on the home-manager foundation merged in #11.

### New modules

- **`home/programs/git.nix`** — full migration of `~/.config/git/config`:
  - `userName` / `userEmail`, `ghq.root`, `core.excludesFile`, `core.editor = "nvim"` (drops the hardcoded `/opt/homebrew/bin/nvim`), `commit.template`, `http.postBuffer`, `push.{default,autoSetupRemote}`, `pull.rebase = false`, custom `phantom.ai` and `user.mail`.
  - 16 aliases including the FZF-driven `co` / `reb` / `mer` / `d` / `stl` / `stp` / `std` / `delete-merged-branch` / `parent`. Single-line `''...''` to keep gitconfig values clean.
  - `includes` for the conditional `~/.gitconfig-personal` under `~/Documents/personal/`.
  - `lfs.enable` for the existing `[filter "lfs"]` block.
  - **Signing not configured**: current config has no `signingkey` / `commit.gpgsign`.

- **`home/programs/fzf.nix`** — `programs.fzf.enable` + `enableZshIntegration`, `defaultOptions` carries the everforest-light palette previously in `FZF_DEFAULT_OPTS`. Custom `Ctrl-r`/`g`/`v`/`o` widgets in `~/.zshrc.backup` still win because `initContent` sources the legacy file after fzf integration.

- **`home/programs/gh.nix`** — `programs.gh.enable`. `gh` removed from `home/packages.nix` to avoid double install.

- **`home/programs/tmux.nix`** — installs `tmux` and places `tmux/tmux.conf` at `~/.config/tmux/tmux.conf` via `xdg.configFile` so the `bind r source-file ~/.config/tmux/tmux.conf` reload binding inside the conf works as-is. `programs.tmux` is intentionally skipped because it writes to `~/.tmux.conf`.

- **`home/programs/gpg.nix`** — writes `~/.gnupg/gpg-agent.conf` with `pinentry-program ${pkgs.pinentry_mac}/Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac`. Realises `pinentry_mac` via store-path reference without polluting PATH (the package only ships an `.app` bundle). Closes the half-measure from Phase 1.

- **`home/default.nix`** — imports the five new modules.

### Brew uninstall after activation

```
brew uninstall git fzf tmux
# already removed in Phase 1: ripgrep fd gh ghq prettierd gpg
# leave installed for now: nvim mise lua luarocks  (Phase 3 / 4 will replace)
```

### Out of scope

- `programs.neovim` and editor-related migration (Phase 3 — alongside `kitty.nix` / `claude.nix`).
- `homebrew.nix` for cask declarations (Phase 4 plan).
- mise → nix runtimes + `.zshrc` cleanup (Phase 4).
- Commit signing config (revisit if/when the user adopts a signing key; gpg-agent.conf is already wired so adding `signingkey` + `commit.gpgsign = true` later is a one-line addition).

## Test plan

On the target Mac:

- [x] `nix flake check` passes.
- [x] `nix run nix-darwin -- build --flake .#mihiro-mac` produces `./result` without errors.
- [x] `sudo darwin-rebuild switch --flake .#mihiro-mac` activates.
- [x] Existing `~/.config/git/config` (legacy symlink) is renamed to `.config/git/config.backup` and the new `~/.config/git/config` is a nix-store symlink.
- [x] `git config --list --show-origin` enumerates expected fields from the new file.
- [x] `git co`, `git stl`, `git parent`, `git delete-merged-branch` all work in a real repo (no escape damage).
- [x] `which git fzf gh tmux` all resolve under `/etc/profiles/per-user/mihiro/bin/`.
- [x] FZF prompt color is unchanged from before.
- [ ] ~~tmux config reload via `prefix r` succeeds: `bind r source-file ~/.config/tmux/tmux.conf` finds the file.~~
- [ ] ~~`cat ~/.gnupg/gpg-agent.conf` shows the pinentry-program pointing into `/nix/store/...`.~~
- [ ] ~~`gpg-connect-agent reloadagent /bye` succeeds; `echo test | gpg --clearsign --local-user <key>` (if any key is present) prompts via the macOS dialog.~~
- [x] `brew uninstall git fzf tmux` succeeds; `which git` continues to resolve to nix profile.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated fzf for fuzzy file searching with Zsh integration and custom color scheme
  * Enabled GitHub CLI support
  * Enhanced Git configuration with LFS, custom aliases, and interactive branch management tools
  * Configured GPG agent with macOS pinentry support
  * Added Tmux terminal multiplexer with preconfigured settings

* **Chores**
  * Reorganized development tool configurations into dedicated modular structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->