### PR TITLE
feat(nix): Phase 3 — neovim, kitty, karabiner, ghostty, claude, iterm2 modules

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -3,10 +3,16 @@
 {
   imports = [
     ./packages.nix
+    ./programs/claude.nix
     ./programs/fzf.nix
     ./programs/gh.nix
+    ./programs/ghostty.nix
     ./programs/git.nix
     ./programs/gpg.nix
+    ./programs/iterm2.nix
+    ./programs/karabiner.nix
+    ./programs/kitty.nix
+    ./programs/neovim.nix
     ./programs/tmux.nix
     ./programs/zsh.nix
   ];

--- a/home/programs/claude.nix
+++ b/home/programs/claude.nix
@@ -1,0 +1,21 @@
+{ config, dotfilesPath, ... }:
+
+{
+  # ~/.claude/ holds Claude Code's global config, skills, and the
+  # statusline script. claude CLI may write to settings.json (e.g. when
+  # adding MCP servers or hooks), so we mkOutOfStoreSymlink each entry
+  # to the repo path rather than putting them in the readonly nix store.
+  # The claude binary itself is installed via the official curl
+  # installer and lives under ~/.local/bin/.
+  home.file.".claude/CLAUDE.md".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/CLAUDE.md";
+
+  home.file.".claude/settings.json".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/settings.json";
+
+  home.file.".claude/skills".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/skills";
+
+  home.file.".claude/statusline-command.sh".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/statusline-command.sh";
+}

--- a/home/programs/ghostty.nix
+++ b/home/programs/ghostty.nix
@@ -1,0 +1,15 @@
+{ config, dotfilesPath, ... }:
+
+{
+  # cmux is the macOS app shell built on Ghostty. It reads ghostty
+  # rendering settings from ~/.config/ghostty/config and its own
+  # app-level prefs from ~/.config/cmux/settings.json. Match the legacy
+  # individual-file symlinks (not whole directories) so a future
+  # standalone Ghostty install can manage other files under
+  # ~/.config/ghostty/ without conflict.
+  home.file.".config/ghostty/config".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/cmux/ghostty/config";
+
+  home.file.".config/cmux/settings.json".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/cmux/settings.json";
+}

--- a/home/programs/iterm2.nix
+++ b/home/programs/iterm2.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+let
+  plistPath = ./../../iterm/com.googlecode.iterm2.plist;
+in
+{
+  # iTerm2 stores its preferences in
+  # ~/Library/Preferences/com.googlecode.iterm2.plist, but cfprefsd
+  # caches that file in memory and rewrites it on quit, so a plain
+  # symlink or `cp` is overwritten. Use `defaults import` to push the
+  # repo plist into cfprefsd, then kill the daemon so the next read
+  # picks up the new values.
+  #
+  # Trade-off: every activation re-imports, so any iTerm2 preference
+  # changes made through the GUI must be exported back into the repo
+  # plist before the next switch or they will be lost.
+  home.activation.iterm2ImportPlist =
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ -f ${plistPath} ]; then
+        /usr/bin/defaults import com.googlecode.iterm2 ${plistPath}
+        /usr/bin/killall cfprefsd 2>/dev/null || true
+      fi
+    '';
+}

--- a/home/programs/karabiner.nix
+++ b/home/programs/karabiner.nix
@@ -1,0 +1,11 @@
+{ config, dotfilesPath, ... }:
+
+{
+  # Karabiner-Elements writes karabiner.json back to ~/.config/karabiner
+  # whenever rules are edited via the GUI, so the target must be a
+  # writeable path (the repo) rather than a readonly nix store copy.
+  # The Karabiner-Elements.app itself is still provided by the brew cask
+  # until Phase 4.
+  home.file.".config/karabiner".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/karabiner";
+}

--- a/home/programs/kitty.nix
+++ b/home/programs/kitty.nix
@@ -1,0 +1,11 @@
+{ config, dotfilesPath, ... }:
+
+{
+  # Whole repo kitty/ directory: kitty.conf, kitty.d/, kitty-themes/,
+  # macos-launch-services-cmdline. mkOutOfStoreSymlink keeps the existing
+  # legacy-symlink target shape so a re-activation does not collide with
+  # what `kitty/setup.sh` previously set up. The kitty.app itself is still
+  # provided by the brew cask until Phase 4.
+  home.file.".config/kitty".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/kitty";
+}

--- a/home/programs/neovim.nix
+++ b/home/programs/neovim.nix
@@ -1,0 +1,12 @@
+{ pkgs, config, dotfilesPath, ... }:
+
+{
+  home.packages = [ pkgs.neovim ];
+
+  # mkOutOfStoreSymlink instead of xdg.configFile.source so lazy.nvim can
+  # keep writing lazy-lock.json back into the repo (and any future cache
+  # files it wants to drop next to init.lua). The repo path is hardcoded
+  # via dotfilesPath in mkHost specialArgs.
+  home.file.".config/nvim".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/nvim";
+}

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -1,8 +1,11 @@
 { inputs, hostName, system, username }:
 
+let
+  dotfilesPath = "/Users/${username}/Documents/personal/dotfiles";
+in
 inputs.nix-darwin.lib.darwinSystem {
   inherit system;
-  specialArgs = { inherit inputs hostName username system; };
+  specialArgs = { inherit inputs hostName username system dotfilesPath; };
   modules = [
     ../darwin
     inputs.home-manager.darwinModules.home-manager
@@ -11,7 +14,7 @@ inputs.nix-darwin.lib.darwinSystem {
         useGlobalPkgs = true;
         useUserPackages = true;
         backupFileExtension = "backup";
-        extraSpecialArgs = { inherit inputs username; };
+        extraSpecialArgs = { inherit inputs username dotfilesPath; };
         users.${username} = import ../home;
       };
     }


### PR DESCRIPTION
## Summary

Phase 3 of the **nix-darwin + home-manager** migration. Moves editor and GUI tooling configs into home-manager modules. GUI app installs themselves (kitty.app, Karabiner-Elements.app, iTerm.app, cmux.app) remain on Homebrew / manual download until Phase 4 adds the nix-darwin homebrew module.

Builds on the program modules merged in #12.

### Pattern: `mkOutOfStoreSymlink` over `xdg.configFile.source`

Most of these tools either auto-write to their config (lazy.nvim's `lazy-lock.json`, Karabiner-Elements GUI edits, claude CLI updating `settings.json`) or are conventionally hand-edited and committed. Pointing `~/.config/<tool>` at the repo path directly via `mkOutOfStoreSymlink` preserves the existing legacy-symlink workflow, whereas `xdg.configFile.source` would import the source into the readonly `/nix/store` and break write-back.

The repo path is centralized as `dotfilesPath` in `lib/mkHost.nix` specialArgs (`/Users/<user>/Documents/personal/dotfiles`) so it isn't sprinkled across modules.

### New modules

- **`home/programs/neovim.nix`** — installs `pkgs.neovim` and symlinks `~/.config/nvim` to the repo `nvim/`. lazy.nvim keeps managing its plugins and writes `lazy-lock.json` back into the repo.
- **`home/programs/kitty.nix`** — symlinks the whole `kitty/` (kitty.conf, kitty.d/, kitty-themes/, macos-launch-services-cmdline). kitty.app stays on brew cask.
- **`home/programs/karabiner.nix`** — symlinks `karabiner/`. Writeable because Karabiner-Elements GUI edits karabiner.json.
- **`home/programs/ghostty.nix`** — individual file symlinks matching the legacy cmux setup: `cmux/ghostty/config` → `~/.config/ghostty/config`, `cmux/settings.json` → `~/.config/cmux/settings.json`.
- **`home/programs/claude.nix`** — four symlinks into `~/.claude/`: `CLAUDE.md`, `settings.json`, `skills/`, `statusline-command.sh`. `settings.json` is writeable because the claude CLI updates it.
- **`home/programs/iterm2.nix`** — `home.activation` hook running `defaults import com.googlecode.iterm2 <plist>` then `killall cfprefsd`. Plain symlink/copy doesn't survive cfprefsd's in-memory cache. Trade-off: every activation overwrites any GUI-side preference changes; export to repo before switching.

### Out of scope

- `pkgs.kitty` / `pkgs.karabiner-elements` / iTerm2 / cmux package installs (Phase 4: nix-darwin homebrew module declares the casks).
- Font management (FiraCode Nerd Font / monaspace). Phase 4 plan migrates `font-monaspice-nerd-font` cask.
- mise → nix runtimes + `.zshrc` cleanup (Phase 4).

### Brew uninstall after activation

```
brew uninstall nvim
# leave installed for now: kitty (cask), karabiner-elements (cask), iterm2 (cask), font-* (cask)
# mise stays until Phase 4
```

## Test plan

On the target Mac (after `git pull origin claude/phase-3-editor-and-gui`):

- [x] `nix flake check` passes.
- [x] `nix run nix-darwin -- build --flake .#mihiro-mac` produces `./result` without errors.
- [x] `sudo darwin-rebuild switch --flake .#mihiro-mac` activates. May surface backup conflicts on `~/.config/{nvim,kitty,karabiner,ghostty,cmux}` and `~/.claude/*` if the legacy symlinks point at the same repo path; if they do match home-manager will silently overwrite, otherwise it auto-renames to `*.backup`.
- [x] `readlink ~/.config/nvim` points at `~/Documents/personal/dotfiles/nvim` (NOT `/nix/store/...`).
- [x] Same for `~/.config/kitty`, `~/.config/karabiner`, `~/.claude/settings.json`.
- [ ] `which nvim` returns `/etc/profiles/per-user/mihiro/bin/nvim`.
- [x] `nvim` opens cleanly, `:Lazy sync` works, edit `lazy-lock.json` in repo via plugin update reflects.
- [x] kitty starts and uses the new theme/config.
- [x] Karabiner-Elements picks up the rules (may need a System Settings > Privacy permission rerun).
- [x] cmux/Ghostty starts with config applied.
- [ ] `~/.claude/settings.json` is a symlink and `claude --version` works.
- [x] iTerm2 prefs (color scheme, font, key bindings) reflect the imported plist after a relaunch.
- [x] `brew uninstall nvim` succeeds; `which nvim` continues to resolve to nix profile.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2)_