### PR TITLE
feat(nix): Phase 4a — declare brew casks via nix-darwin homebrew module

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./homebrew.nix
     ./nix.nix
     ./system.nix
     ./users.nix

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -18,7 +18,6 @@
       "font-monaspice-nerd-font"
       "fork"
       "gcloud-cli"
-      "homerow"
       "kitty"
       "maccy"
       "orbstack"

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -22,7 +22,6 @@
       "homerow"
       "kitty"
       "maccy"
-      "rio"
     ];
   };
 }

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -15,13 +15,13 @@
     };
 
     casks = [
-      "docker-desktop"
       "font-monaspice-nerd-font"
       "fork"
       "gcloud-cli"
       "homerow"
       "kitty"
       "maccy"
+      "orbstack"
     ];
   };
 }

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -1,0 +1,28 @@
+{ ... }:
+
+{
+  homebrew = {
+    enable = true;
+
+    onActivation = {
+      autoUpdate = false;
+      upgrade = false;
+      # Uninstall casks that are present in brew but no longer declared
+      # below. Set to "zap" to also wipe app support data; leaving as
+      # "uninstall" so removing a line drops the cask but keeps user
+      # state if reinstalled later.
+      cleanup = "uninstall";
+    };
+
+    casks = [
+      "docker-desktop"
+      "font-monaspice-nerd-font"
+      "fork"
+      "gcloud-cli"
+      "homerow"
+      "kitty"
+      "maccy"
+      "rio"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

Phase 4a of the migration. Declares the user's Homebrew casks through the nix-darwin `homebrew` module so the GUI app set is now part of the flake.

Builds on Phase 3 (#13). Formulae are intentionally untouched here — they move (or get pruned) in Phase 4b together with the mise → nix runtime migration.

### `darwin/homebrew.nix`

```nix
homebrew = {
  enable = true;
  onActivation = {
    autoUpdate = false;
    upgrade = false;
    cleanup = "uninstall";
  };
  casks = [
    "font-monaspice-nerd-font"
    "fork"
    "gcloud-cli"
    "kitty"
    "maccy"
    "orbstack"
  ];
};
```

- 6 casks declared. The first activation will:
  - Uninstall `rio`, `homerow` (no longer wanted).
  - Uninstall `docker-desktop` and install `orbstack` (Docker runtime swap).
- `cleanup = "uninstall"` — casks dropped from this list get removed on the next `darwin-rebuild switch`. Not `"zap"` so user state under `~/Library/Application Support/<app>/` survives a remove → re-add cycle.
- `autoUpdate = false`, `upgrade = false` — keep `brew update` / `brew upgrade` as a manual operation; activations should not silently pull in new versions across machines.

### Wired in via `darwin/default.nix`

Added to `imports` alphabetically before `nix.nix`.

### Pre-activation note: Docker Desktop → OrbStack

Existing Docker images under Docker Desktop's volume are not migrated automatically. If image preservation matters, export them with `docker save <image> -o image.tar` before the switch and re-import with `docker load -i image.tar` after orbstack starts.

### Out of scope (Phase 4b)

- Brew formulae declaration (`mise`, `luarocks`, `node`, `phantom`, `tailscale`, transitive deps).
- mise → nix runtimes (node/python/go/rust/bun/etc.) inside `home/packages.nix`.
- `.zshrc` cleanup (Phase 4c).

## Test plan

On the target Mac:

- [ ] `nix flake check` passes.
- [ ] `nix run nix-darwin -- build --flake .#mihiro-mac` produces `./result`.
- [ ] `sudo darwin-rebuild switch --flake .#mihiro-mac` activates: removes `rio`, `homerow`, `docker-desktop`; installs `orbstack`; the other five remain unchanged.
- [ ] `brew list --cask` matches the declared list (6 entries; no `rio` / `homerow` / `docker-desktop`).
- [ ] OrbStack starts and `docker version` works against the new daemon.
- [ ] Adding a line to `casks` and re-activating installs the new cask; removing a line uninstalls it.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Homebrew configuration management with automatic updates disabled and specified casks defined for macOS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->