### PR TITLE
fix(nix): disable homebrew cleanup until brews are fully declared

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -8,12 +8,12 @@
       autoUpdate = false;
       upgrade = false;
       # IMPORTANT: cleanup applies to BOTH casks and brew formulae and
-      # there is no per-type override in nix-darwin. Set to null until
+      # there is no per-type override in nix-darwin. Set to "none" until
       # the formulae set is fully declared (planned for Phase 4b after
       # mise is removed); otherwise activation mass-uninstalls anything
       # not listed in `brews`. Removal of a cask currently requires a
       # manual `brew uninstall --cask <name>` after dropping the line.
-      cleanup = null;
+      cleanup = "none";
     };
 
     casks = [

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -7,11 +7,13 @@
     onActivation = {
       autoUpdate = false;
       upgrade = false;
-      # Uninstall casks that are present in brew but no longer declared
-      # below. Set to "zap" to also wipe app support data; leaving as
-      # "uninstall" so removing a line drops the cask but keeps user
-      # state if reinstalled later.
-      cleanup = "uninstall";
+      # IMPORTANT: cleanup applies to BOTH casks and brew formulae and
+      # there is no per-type override in nix-darwin. Set to null until
+      # the formulae set is fully declared (planned for Phase 4b after
+      # mise is removed); otherwise activation mass-uninstalls anything
+      # not listed in `brews`. Removal of a cask currently requires a
+      # manual `brew uninstall --cask <name>` after dropping the line.
+      cleanup = null;
     };
 
     casks = [


### PR DESCRIPTION
## Summary

**Hotfix for Phase 4a (#14).** Disables `homebrew.onActivation.cleanup` so a future `darwin-rebuild switch` does not mass-uninstall brew formulae not listed in `darwin/homebrew.nix`.

### Why

The Phase 4a activation on the actual Mac uninstalled ~41 brew formulae — `mise`, `tailscale`, `phantom`, `neovim`, `node`, `tree-sitter`, `tree`, `lynx`, `asciinema`, `agg`, `pstree`, `usage`, `lpeg`, `luajit`, `luv`, plus all transitive deps that weren't shielded by `gcloud-cli`'s dep-guard. nix-darwin's `homebrew.onActivation.cleanup` does not have per-type granularity: setting it to `"uninstall"` removes both undeclared casks **and** undeclared brews. Phase 4a only declared casks, so every formula not in the cask list was eligible for removal.

Manually-recovered after the fact via `brew install mise tailscale phantom node tree tree-sitter` (recovery shopping list, not exhaustive — the user can reinstall on demand for the long tail).

### Change

```diff
-cleanup = "uninstall";
+cleanup = "none";
```

The first attempt used `cleanup = null`, but the option's type is the string enum `{"none","check","uninstall","zap"}` and is not nullable, so the build failed with a type error. `"none"` is the correct way to express "do nothing on activation".

A multi-line comment in `homebrew.nix` documents the trade-off below.

### Trade-off

- **Lost**: removing a cask line from `casks` no longer auto-uninstalls. Manual step: `brew uninstall --cask <name>` after the diff lands.
- **Gained**: never again wipes formulae the user actually needs.

The plan is to bring `cleanup` back to `"uninstall"` in Phase 4b once the `brews` list is fully enumerated (which is realistic only after `mise` is replaced with nix runtimes, shrinking the formula set to a handful).

## Verification (run on the actual Mac)

- ✅ `nix flake check` passes.
- ✅ `nix run nix-darwin -- build --flake .#mihiro-mac` produces `./result`.
- ✅ `sudo darwin-rebuild switch --flake .#mihiro-mac` activates with no `Uninstalled N formulae` line — every cask emits `Using <name>` only and the formula set is untouched.
- ✅ `brew list --formula` count preserved (41 entries; identical to pre-activation snapshot).
- ✅ `brew list --cask` is unchanged at six entries: `font-monaspice-nerd-font`, `fork`, `gcloud-cli`, `kitty`, `maccy`, `orbstack`.
- ✅ home-manager activation hooks (`iterm2ImportPlist`, `reloadGpgAgent`) report `OK`.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2