### PR TITLE
feat(nix): Phase 4d — migrate tailscale (CLI + daemon) from brew to nix

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -6,6 +6,7 @@
     ./homebrew.nix
     ./nix.nix
     ./system.nix
+    ./tailscale.nix
     ./users.nix
   ];
 

--- a/darwin/tailscale.nix
+++ b/darwin/tailscale.nix
@@ -1,25 +1,5 @@
-{ pkgs, ... }:
+{ ... }:
 
 {
-  # Replaces the brew formula `tailscale` (CLI + tailscaled daemon).
-  # brew installed tailscaled with no flags, relying on the macOS-default
-  # state path /Library/Tailscale/tailscaled.state. Reusing that exact
-  # path here lets the new nix daemon adopt the existing tailnet auth
-  # state without re-login.
-
-  environment.systemPackages = [ pkgs.tailscale ];
-
-  launchd.daemons.tailscaled = {
-    serviceConfig = {
-      Label = "com.tailscale.tailscaled";
-      ProgramArguments = [
-        "${pkgs.tailscale}/bin/tailscaled"
-        "--state=/Library/Tailscale/tailscaled.state"
-      ];
-      RunAtLoad = true;
-      KeepAlive = true;
-      StandardErrorPath = "/var/log/tailscaled.log";
-      StandardOutPath = "/var/log/tailscaled.log";
-    };
-  };
+  services.tailscale.enable = true;
 }

--- a/darwin/tailscale.nix
+++ b/darwin/tailscale.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+
+{
+  # Replaces the brew formula `tailscale` (CLI + tailscaled daemon).
+  # The brew formula registered tailscaled as a launchd daemon under
+  # /Library/LaunchDaemons/homebrew.mxcl.tailscale.plist with state at
+  # /opt/homebrew/var/lib/tailscale/. The migration moves both the CLI
+  # and the daemon into the nix store and the daemon's state file to
+  # the FHS-standard /var/lib/tailscale/.
+
+  environment.systemPackages = [ pkgs.tailscale ];
+
+  launchd.daemons.tailscaled = {
+    serviceConfig = {
+      Label = "com.tailscale.tailscaled";
+      ProgramArguments = [
+        "${pkgs.tailscale}/bin/tailscaled"
+        "--state=/var/lib/tailscale/tailscaled.state"
+        "--socket=/var/run/tailscaled.socket"
+        "--port=41641"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardErrorPath = "/var/log/tailscaled.log";
+      StandardOutPath = "/var/log/tailscaled.log";
+    };
+  };
+}

--- a/darwin/tailscale.nix
+++ b/darwin/tailscale.nix
@@ -2,11 +2,10 @@
 
 {
   # Replaces the brew formula `tailscale` (CLI + tailscaled daemon).
-  # The brew formula registered tailscaled as a launchd daemon under
-  # /Library/LaunchDaemons/homebrew.mxcl.tailscale.plist with state at
-  # /opt/homebrew/var/lib/tailscale/. The migration moves both the CLI
-  # and the daemon into the nix store and the daemon's state file to
-  # the FHS-standard /var/lib/tailscale/.
+  # brew installed tailscaled with no flags, relying on the macOS-default
+  # state path /Library/Tailscale/tailscaled.state. Reusing that exact
+  # path here lets the new nix daemon adopt the existing tailnet auth
+  # state without re-login.
 
   environment.systemPackages = [ pkgs.tailscale ];
 
@@ -15,9 +14,7 @@
       Label = "com.tailscale.tailscaled";
       ProgramArguments = [
         "${pkgs.tailscale}/bin/tailscaled"
-        "--state=/var/lib/tailscale/tailscaled.state"
-        "--socket=/var/run/tailscaled.socket"
-        "--port=41641"
+        "--state=/Library/Tailscale/tailscaled.state"
       ];
       RunAtLoad = true;
       KeepAlive = true;


### PR DESCRIPTION
## Summary

Phase 4d of the migration. Moves tailscale (CLI **and** the `tailscaled` daemon) from the homebrew formula to nix so the entire VPN stack is pinned by `flake.lock`. After this PR `tailscale` is no longer in the brew formula list (only `phantom` remains, kept on brew because of its hard `/opt/homebrew/opt/node` shebang).

Builds on Phase 4c (#18). Independent of Phase 5 (`setup.sh` cleanup).

### `darwin/tailscale.nix` (new)

```nix
{ ... }:

{
  services.tailscale.enable = true;
}
```

That is the entire module. nix-darwin's `services.tailscale` module turns out to be supported on Darwin and expands to:

- `environment.systemPackages` adds `pkgs.tailscale` (CLI + daemon).
- `launchd.daemons.tailscaled` registers `com.tailscale.tailscaled` with `RunAtLoad = true`, `KeepAlive = true`, no explicit `--state` flag — `tailscaled` falls back to the macOS default `/Library/Tailscale/tailscaled.state`, which is the same path the brew formula was using. The existing tailnet auth state is therefore inherited automatically and no re-login is required.

`darwin/default.nix` imports the new module.

### How this evolved

The first iteration of the module wrote `launchd.daemons.tailscaled` by hand because I was unsure whether `services.tailscale` had darwin support (history: f228… and 8370916). After verification on the Mac (the option type-checked under `nix flake check` and the activation produced an equivalent plist), the module collapsed into the one-liner above.

## Migration steps (verified end-to-end on the actual Mac)

```bash
git pull --ff-only

# 1. Stop the brew daemon and remove the formula. The brew launchd
#    plist is unloaded as part of `brew services stop`. The state
#    file at /Library/Tailscale/tailscaled.state survives.
sudo brew services stop tailscale
brew uninstall tailscale       # may leave an older keg behind, see cleanup
brew uninstall --force tailscale  # only if the previous step warns about a leftover version
sudo rm -rf /opt/homebrew/Cellar/tailscale  # if `brew uninstall --force` says "could not remove keg"

# 2. Activate the nix daemon. nix-darwin writes its plist as
#    com.tailscale.tailscaled and registers it with launchd. The
#    daemon comes up referencing the existing state file, so the
#    tailnet session is preserved.
sudo darwin-rebuild switch --flake .#mihiro-mac

# 3. Verify in a fresh login shell.
exec $SHELL -l
which tailscale          # /run/current-system/sw/bin/tailscale
tailscale --version      # 1.96.5 (no version skew warning)
sudo launchctl list | grep tailscale
ps aux | grep tailscaled | grep -v grep
tailscale status         # online peers identical to before
```

If `tailscale status` reports `Logged out`, run `sudo tailscale up --operator=mihiro` once. (Did not happen during testing — the state file transition was clean.)

### Post-migration cleanup (optional)

`sudo systemextensionsctl list` shows a leftover `io.tailscale.ipn.macsys.network-extension` from a previous Tailscale.app install. It is harmless because the active VPN engine is now the nix `tailscaled`, not the kernel extension. Removing it requires either temporarily disabling SIP for `systemextensionsctl reset`, or using a System Settings → General → Login Items & Extensions → Network Extensions toggle. Not required.

### Rollback

Reinstall the brew formula and switch to the previous nix-darwin generation:

```bash
brew install tailscale
sudo brew services start tailscale
sudo darwin-rebuild switch --flake .#mihiro-mac~1
```

## Out of scope

- `phantom` is the only brew formula left. It needs to stay there because its CLI has a hard-coded `#!/opt/homebrew/opt/node/bin/node` shebang patched manually in Phase 4b. Migrating it requires either upstream support for env-resolved interpreters or moving it onto npm-via-nix.
- Re-enabling `homebrew.onActivation.cleanup = "uninstall"` is the natural follow-up once the formula list (now effectively `[ "phantom" ]`) is enumerated explicitly. Worth a small PR after this lands.

## Test plan (already executed)

- [x] `nix flake check` passes (option `services.tailscale.enable` accepted on darwin).
- [x] `darwin-rebuild build --flake .#mihiro-mac` produces `./result`.
- [x] After running the migration steps:
  - [x] `which tailscale` resolves under `/run/current-system/sw/bin/`.
  - [x] `ps aux | grep tailscaled` shows the daemon path under `/nix/store/...-tailscale-1.96.5/bin/tailscaled`.
  - [x] `sudo launchctl list | grep tailscale` shows `com.tailscale.tailscaled` running, status 0.
  - [x] `tailscale status` reports the same online peers as before with no client/server version skew warning.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2