### PR TITLE
feat(nix): Phase 6 — flake apps for build / switch / update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,18 +12,21 @@ Declarative macOS dotfiles. The whole environment — shell, editor, terminals, 
 # Type-check and option-name validate without building artifacts
 nix flake check
 
-# Evaluate and build the closure into ./result without activating
-darwin-rebuild build --flake .#mihiro-mac
+# Build the system closure into ./result without activating
+nix run .#build
 
-# Activate (requires sudo because it reloads launchd daemons and writes /etc)
-sudo darwin-rebuild switch --flake .#mihiro-mac
+# Activate (handles sudo internally)
+nix run .#switch
+
+# Refresh flake.lock (then `nix run .#switch` to apply)
+nix run .#update
 
 # Roll back
 darwin-rebuild --list-generations
 sudo darwin-rebuild switch --flake .#mihiro-mac~1
 ```
 
-`darwin-rebuild` is preferred over `nix run nix-darwin -- ...`; the latter hits the unauthenticated GitHub API.
+`nix run .#switch` wraps `darwin-rebuild switch --flake .#mihiro-mac` — the rebuild binary it invokes is the one built from this flake's pinned `nix-darwin` input, so no GitHub round-trip per activation.
 
 ## Architecture
 
@@ -81,7 +84,7 @@ Editing the file in the repo path is the same as editing the file at the symlink
 
 ### Add a CLI tool
 
-Edit `home/packages.nix`, append the nixpkgs attribute name, run `darwin-rebuild switch`.
+Edit `home/packages.nix`, append the nixpkgs attribute name, run `nix run .#switch`.
 
 ### Add a `programs.<tool>` module
 
@@ -101,9 +104,9 @@ Edit `home/programs/zsh.nix`:
 ### Bump pinned packages
 
 ```bash
-nix flake update                # update all inputs
-nix flake update <input-name>   # update one
-sudo darwin-rebuild switch --flake .#mihiro-mac
+nix run .#update                # update all inputs
+nix flake update <input-name>   # update one specific input
+nix run .#switch                # apply
 ```
 
 ## Caveats

--- a/README.md
+++ b/README.md
@@ -5,37 +5,40 @@
 [![nix-darwin](https://img.shields.io/badge/nix--darwin-managed-success.svg)](https://github.com/LnL7/nix-darwin)
 [![home-manager](https://img.shields.io/badge/home--manager-managed-success.svg)](https://github.com/nix-community/home-manager)
 
-Declarative macOS dotfiles managed with [Nix flakes](https://nixos.wiki/wiki/Flakes), [nix-darwin](https://github.com/LnL7/nix-darwin) and [home-manager](https://github.com/nix-community/home-manager). One `darwin-rebuild switch` rebuilds the system: shell, editor, terminals, fonts, GUI apps, language runtimes, GPG agent, Tailscale, all at once and pinned by `flake.lock`.
+Declarative macOS dotfiles managed with [Nix flakes](https://nixos.wiki/wiki/Flakes), [nix-darwin](https://github.com/LnL7/nix-darwin) and [home-manager](https://github.com/nix-community/home-manager). One `nix run .#switch` rebuilds the system: shell, editor, terminals, fonts, GUI apps, language runtimes, GPG agent, Tailscale, all at once and pinned by `flake.lock`.
 
 ## Quick start (fresh Mac)
 
 ```bash
-# 1. Install nix (Determinate Systems installer recommended)
+# 1. Install Nix (Determinate Systems installer enables flakes by default)
 curl -fsSL https://install.determinate.systems/nix | sh -s -- install
 
-# 2. Clone this repo to a stable path
+# 2. Clone this repo
 git clone git@github.com:MihiroH/dotfiles.git ~/Documents/personal/dotfiles
 cd ~/Documents/personal/dotfiles
 
-# 3. First-time bootstrap only — required because `darwin-rebuild` is not yet
-#    on PATH. This is the one place this repo uses `nix run nix-darwin`; it
-#    may hit the unauthenticated GitHub API rate limit and fall back to the
-#    cached version. After this step always use the form in step 4.
-sudo nix --extra-experimental-features 'nix-command flakes' \
-  run nix-darwin -- switch --flake .#mihiro-mac
-
-# 4. From here on, every rebuild goes through darwin-rebuild (reads
-#    flake.lock, no GitHub round-trip needed):
-sudo darwin-rebuild switch --flake .#mihiro-mac
+# 3. Activate (works for both first-time bootstrap and every subsequent rebuild)
+nix run .#switch
 ```
 
-The host configuration is `darwinConfigurations."mihiro-mac"` (Apple Silicon). To target a different machine, copy that block in `flake.nix` and add a new entry to `lib/mkHost.nix`.
+The host configuration is `darwinConfigurations."mihiro-mac"` (Apple Silicon). To target a different machine, edit `hostName` / `system` / `username` at the top of `flake.nix`.
+
+## Daily commands
+
+```bash
+nix run .#build      # build into ./result without activating
+nix run .#switch     # build + activate (sudo prompt)
+nix run .#update     # nix flake update
+nix flake check      # type-check all options
+```
+
+These wrap the underlying `darwin-rebuild` and `nix flake` invocations so the host name (`.#mihiro-mac`) does not have to be retyped.
 
 ## Repository layout
 
 ```text
 dotfiles/
-├── flake.nix              # inputs (nixpkgs, nix-darwin, home-manager) + outputs
+├── flake.nix              # inputs (nixpkgs, nix-darwin, home-manager) + outputs (darwinConfigurations + apps)
 ├── flake.lock
 ├── lib/
 │   └── mkHost.nix         # darwinSystem factory; passes specialArgs (incl. dotfilesPath)
@@ -90,34 +93,25 @@ The `mkOutOfStoreSymlink` modules point at the repo path (`/Users/<user>/Documen
 | **Brew formulae** | `darwin/homebrew.nix` — `phantom` only (cmux completion CLI with hard-coded shebang) |
 | **iTerm2 plist** | `home/programs/iterm2.nix` — `defaults import` + `killall cfprefsd` activation |
 
-`homebrew.onActivation.cleanup = "uninstall"`: anything brew has installed that is not in `brews` / `casks` is removed on the next `darwin-rebuild switch`.
+`homebrew.onActivation.cleanup = "uninstall"`: anything brew has installed that is not in `brews` / `casks` is removed on the next switch.
 
 ## Common tasks
 
 ### Update an upstream package
 
 ```bash
-# Update a specific input (or omit the arg to update all)
-nix flake update home-manager
-sudo darwin-rebuild switch --flake .#mihiro-mac
+nix run .#update              # all inputs
+nix flake update home-manager # one input
+nix run .#switch              # apply
 ```
 
 ### Add a CLI
 
-Edit `home/packages.nix`, append the attribute name, then `darwin-rebuild switch`.
+Edit `home/packages.nix`, append the attribute name, then `nix run .#switch`.
 
 ### Add a brew cask
 
 Edit the `casks = [ ... ]` list in `darwin/homebrew.nix`. Removing a line uninstalls the cask (because of `cleanup = "uninstall"`).
-
-### Verify a build without activating
-
-```bash
-nix flake check
-darwin-rebuild build --flake .#mihiro-mac
-```
-
-`nix flake check` runs in seconds and catches option-name typos. `darwin-rebuild build` actually builds the closure into `./result/`.
 
 ### Roll back
 
@@ -143,10 +137,10 @@ export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/legacy_credentials/<
 
 ## Caveats
 
-- **`nix run nix-darwin -- ...`** hits the unauthenticated GitHub API (60 req/h) and may fall back to the cached version with a 403 warning. Use `darwin-rebuild` directly once it is on PATH; it reads `flake.lock` instead.
 - **macOS App Management permission**: the first activation that touches `~/Applications/Home Manager Apps/` (kitty / Maccy via nix) requires you to grant the active terminal "App Management" in System Settings → Privacy & Security.
 - **Tailscale state**: `services.tailscale.enable` keeps the auth state at `/Library/Tailscale/tailscaled.state`. Migrating from the brew formula adopts that path automatically — no re-login required.
 - **`phantom` shebang**: the cmux completion CLI installs with `#!/opt/homebrew/opt/node/bin/node` hard-coded. After moving Node to nix the binary is patched in place to `#!/usr/bin/env node`. Re-running `brew reinstall phantom` would reset that patch.
+- **Non-Determinate Nix installers**: official `https://nixos.org/download` does not enable flakes by default. If you used the official installer, prepend `--extra-experimental-features 'nix-command flakes'` to the first `nix run .#switch`, or add `experimental-features = nix-command flakes` to `~/.config/nix/nix.conf`.
 
 ## License
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "mihiro-mac dotfiles (nix-darwin + home-manager migration)";
+  description = "mihiro-mac dotfiles (nix-darwin + home-manager)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -19,16 +19,59 @@
     let
       forAllSystems = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-darwin" ];
       mkHost = import ./lib/mkHost.nix;
+
+      hostName = "mihiro-mac";
+      system = "aarch64-darwin";
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # darwin-rebuild built from this flake's pinned nix-darwin input.
+      # Using this path means `nix run .#switch` does not have to fetch
+      # nix-darwin from GitHub on every invocation (which trips the
+      # unauthenticated API rate limit).
+      darwinRebuild =
+        "${self.darwinConfigurations.${hostName}.config.system.build.darwin-rebuild}/bin/darwin-rebuild";
     in
     {
-      darwinConfigurations."mihiro-mac" = mkHost {
-        inherit inputs;
-        hostName = "mihiro-mac";
-        system = "aarch64-darwin";
+      darwinConfigurations.${hostName} = mkHost {
+        inherit inputs hostName system;
         username = "mihiro";
       };
 
-      formatter = forAllSystems (system:
-        nixpkgs.legacyPackages.${system}.nixpkgs-fmt);
+      formatter = forAllSystems (sys:
+        nixpkgs.legacyPackages.${sys}.nixpkgs-fmt);
+
+      apps.${system} = {
+        # Build the darwin system closure into ./result without activating.
+        build = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "darwin-build" ''
+            set -e
+            echo "Building darwin configuration..."
+            nix build .#darwinConfigurations.${hostName}.system "$@"
+            echo "Build successful. Run 'nix run .#switch' to apply."
+          '');
+        };
+
+        # Activate the darwin system. Wraps darwin-rebuild switch so the
+        # caller does not have to remember --flake .#${hostName}.
+        switch = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "darwin-switch" ''
+            set -eo pipefail
+            exec sudo ${darwinRebuild} switch --flake .#${hostName} "$@"
+          '');
+        };
+
+        # Refresh flake.lock for all (or selected) inputs.
+        update = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "flake-update" ''
+            set -e
+            echo "Updating flake.lock..."
+            nix flake update "$@"
+            echo "Done. Run 'nix run .#switch' to apply changes."
+          '');
+        };
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
         # Build the darwin system closure into ./result without activating.
         build = {
           type = "app";
+          meta.description = "Build the darwin system into ./result without activating";
           program = toString (pkgs.writeShellScript "darwin-build" ''
             set -e
             echo "Building darwin configuration..."
@@ -56,6 +57,7 @@
         # caller does not have to remember --flake .#${hostName}.
         switch = {
           type = "app";
+          meta.description = "Build and activate the darwin system";
           program = toString (pkgs.writeShellScript "darwin-switch" ''
             set -eo pipefail
             exec sudo ${darwinRebuild} switch --flake .#${hostName} "$@"
@@ -65,6 +67,7 @@
         # Refresh flake.lock for all (or selected) inputs.
         update = {
           type = "app";
+          meta.description = "Refresh flake.lock (run nix run .#switch afterwards)";
           program = toString (pkgs.writeShellScript "flake-update" ''
             set -e
             echo "Updating flake.lock..."


### PR DESCRIPTION
## Summary

Phase 6: add flake `apps` outputs so the daily commands collapse to `nix run .#build` / `nix run .#switch` / `nix run .#update`, and rewrite the README quick-start around them.

Builds on Phase 5 (#21) — purely an ergonomics layer, no behavioural change to the underlying `darwin-rebuild` invocations.

### `flake.nix`

```nix
let
  hostName = "mihiro-mac";
  system = "aarch64-darwin";
  pkgs = nixpkgs.legacyPackages.${system};

  darwinRebuild =
    "${self.darwinConfigurations.${hostName}.config.system.build.darwin-rebuild}/bin/darwin-rebuild";
in
{
  darwinConfigurations.${hostName} = mkHost { ... };
  formatter = forAllSystems (sys: nixpkgs.legacyPackages.${sys}.nixpkgs-fmt);

  apps.${system} = {
    build = {
      type = "app";
      meta.description = "Build the darwin system into ./result without activating";
      program = ''nix build .#darwinConfigurations.${hostName}.system "$@"'';
    };
    switch = {
      type = "app";
      meta.description = "Build and activate the darwin system";
      program = ''exec sudo ${darwinRebuild} switch --flake .#${hostName} "$@"'';
    };
    update = {
      type = "app";
      meta.description = "Refresh flake.lock (run nix run .#switch afterwards)";
      program = ''nix flake update "$@"'';
    };
  };
}
```

Two design choices:

1. **No flake-parts**, no `perSystem`. We only target one host on one architecture; importing flake-parts for three short scripts would cost more than it saves.
2. **`switch` uses `${self.darwinConfigurations.<host>.config.system.build.darwin-rebuild}` instead of `nix run nix-darwin -- switch`.** That binary is built from the pinned `nix-darwin` input, so activation no longer fetches `nix-darwin` from GitHub on every invocation. This is the mechanism that lets `nix run .#switch` work for both first-time bootstrap and every subsequent rebuild — the GitHub API rate-limit warning that has shadowed every previous phase finally goes away from the activation path.

`meta.description` on each app removes the three "app lacks attribute 'meta'" warnings from `nix flake check` and surfaces in `nix flake show`.

### Quick start before / after

```diff
-# 1. Install Nix
+# 1. Install Nix (Determinate Systems installer enables flakes by default)
 curl -fsSL https://install.determinate.systems/nix | sh -s -- install

-# 2. Clone this repo to a stable path
+# 2. Clone this repo
 git clone git@github.com:MihiroH/dotfiles.git ~/Documents/personal/dotfiles
 cd ~/Documents/personal/dotfiles

-# 3. First-time bootstrap only — required because `darwin-rebuild` is not yet
-#    on PATH. This is the one place this repo uses `nix run nix-darwin`; it
-#    may hit the unauthenticated GitHub API rate limit and fall back to the
-#    cached version. After this step always use the form in step 4.
-sudo nix --extra-experimental-features 'nix-command flakes' \
-  run nix-darwin -- switch --flake .#mihiro-mac
-
-# 4. From here on, every rebuild goes through darwin-rebuild (reads
-#    flake.lock, no GitHub round-trip needed):
-sudo darwin-rebuild switch --flake .#mihiro-mac
+# 3. Activate (works for both first-time bootstrap and every subsequent rebuild)
+nix run .#switch
```

The "first run is special" exception is gone. The only nuance left for non-Determinate-Nix users is whether flakes are pre-enabled, which is mentioned once in Caveats.

## Verification (run on the actual Mac)

- ✅ `nix flake check` passes with no warnings (the three "app lacks attribute 'meta'" notices are gone after the `meta.description` follow-up commit).
- ✅ `nix flake show` lists `apps.aarch64-darwin.{build,switch,update}` each with its description, alongside the existing `darwinConfigurations` and `formatter` outputs.
- ✅ `nix run .#build` builds `./result` and prints "Build successful. Run 'nix run .#switch' to apply."
- ✅ `nix run .#switch` activates end-to-end. brew bundle reports `Using phantom / fork / orbstack`, every home-manager activation step (`copyApps`, `iterm2ImportPlist`, `reloadGpgAgent`, `setupLaunchAgents`) returns OK, and **no GitHub API warning appears** during activation.
- ✅ `nix run .#switch -- --help` propagates `--help` through to `darwin-rebuild` and prints the full usage.
- ⚠ `nix run .#update` is unchanged in behaviour — it still calls `nix flake update`, which contacts the unauthenticated GitHub API once per input and may hit the 60 req/h rate limit. Out of scope for this PR; the workaround is the standard `~/.config/nix/nix.conf access-tokens = github.com=ghp_...` setup if it bites.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2