### PR TITLE
docs: correct phantom description (Git worktree manager, not cmux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The `mkOutOfStoreSymlink` modules point at the repo path (`/Users/<user>/Documen
 | **System fonts** | `darwin/fonts.nix` — `nerd-fonts.monaspace` |
 | **Tailscale** | `darwin/tailscale.nix` — `services.tailscale.enable = true` (CLI + tailscaled launchd daemon) |
 | **Brew casks** | `darwin/homebrew.nix` — `fork`, `orbstack` (apps that need privileged installers) |
-| **Brew formulae** | `darwin/homebrew.nix` — `phantom` only ([Git worktree manager](https://github.com/phantompane/phantom) with hard-coded brew-node shebang) |
+| **Brew formulae** | `darwin/homebrew.nix` — `phantom` only ([Git worktree manager](https://github.com/phantompane/phantom); not in nixpkgs) |
 | **iTerm2 plist** | `home/programs/iterm2.nix` — `defaults import` + `killall cfprefsd` activation |
 
 `homebrew.onActivation.cleanup = "uninstall"`: anything brew has installed that is not in `brews` / `casks` is removed on the next switch.
@@ -139,7 +139,6 @@ export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/legacy_credentials/<
 
 - **macOS App Management permission**: the first activation that touches `~/Applications/Home Manager Apps/` (kitty / Maccy via nix) requires you to grant the active terminal "App Management" in System Settings → Privacy & Security.
 - **Tailscale state**: `services.tailscale.enable` keeps the auth state at `/Library/Tailscale/tailscaled.state`. Migrating from the brew formula adopts that path automatically — no re-login required.
-- **`phantom` shebang**: the [Git worktree manager](https://github.com/phantompane/phantom) installs with `#!/opt/homebrew/opt/node/bin/node` hard-coded. After moving Node to nix the binary is patched in place to `#!/usr/bin/env node`. Re-running `brew reinstall phantom` would reset that patch.
 - **Non-Determinate Nix installers**: official `https://nixos.org/download` does not enable flakes by default. If you used the official installer, prepend `--extra-experimental-features 'nix-command flakes'` to the first `nix run .#switch`, or add `experimental-features = nix-command flakes` to `~/.config/nix/nix.conf`.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The `mkOutOfStoreSymlink` modules point at the repo path (`/Users/<user>/Documen
 | **System fonts** | `darwin/fonts.nix` — `nerd-fonts.monaspace` |
 | **Tailscale** | `darwin/tailscale.nix` — `services.tailscale.enable = true` (CLI + tailscaled launchd daemon) |
 | **Brew casks** | `darwin/homebrew.nix` — `fork`, `orbstack` (apps that need privileged installers) |
-| **Brew formulae** | `darwin/homebrew.nix` — `phantom` only (cmux completion CLI with hard-coded shebang) |
+| **Brew formulae** | `darwin/homebrew.nix` — `phantom` only ([Git worktree manager](https://github.com/phantompane/phantom) with hard-coded brew-node shebang) |
 | **iTerm2 plist** | `home/programs/iterm2.nix` — `defaults import` + `killall cfprefsd` activation |
 
 `homebrew.onActivation.cleanup = "uninstall"`: anything brew has installed that is not in `brews` / `casks` is removed on the next switch.
@@ -139,7 +139,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/legacy_credentials/<
 
 - **macOS App Management permission**: the first activation that touches `~/Applications/Home Manager Apps/` (kitty / Maccy via nix) requires you to grant the active terminal "App Management" in System Settings → Privacy & Security.
 - **Tailscale state**: `services.tailscale.enable` keeps the auth state at `/Library/Tailscale/tailscaled.state`. Migrating from the brew formula adopts that path automatically — no re-login required.
-- **`phantom` shebang**: the cmux completion CLI installs with `#!/opt/homebrew/opt/node/bin/node` hard-coded. After moving Node to nix the binary is patched in place to `#!/usr/bin/env node`. Re-running `brew reinstall phantom` would reset that patch.
+- **`phantom` shebang**: the [Git worktree manager](https://github.com/phantompane/phantom) installs with `#!/opt/homebrew/opt/node/bin/node` hard-coded. After moving Node to nix the binary is patched in place to `#!/usr/bin/env node`. Re-running `brew reinstall phantom` would reset that patch.
 - **Non-Determinate Nix installers**: official `https://nixos.org/download` does not enable flakes by default. If you used the official installer, prepend `--extra-experimental-features 'nix-command flakes'` to the first `nix run .#switch`, or add `experimental-features = nix-command flakes` to `~/.config/nix/nix.conf`.
 
 ## License

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -13,8 +13,10 @@
     };
 
     brews = [
-      # phantom ships with a hard-coded `#!/opt/homebrew/opt/node/bin/node`
-      # shebang, so it can't be moved to nix without upstream changes.
+      # Git worktree manager (phantompane/phantom). The brew bottle ships
+      # with a hard-coded `#!/opt/homebrew/opt/node/bin/node` shebang, so
+      # moving it to nix would require either upstream support for
+      # `#!/usr/bin/env node` or rebuilding it via npm-on-nix.
       "phantom"
     ];
 

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -13,10 +13,9 @@
     };
 
     brews = [
-      # Git worktree manager (phantompane/phantom). The brew bottle ships
-      # with a hard-coded `#!/opt/homebrew/opt/node/bin/node` shebang, so
-      # moving it to nix would require either upstream support for
-      # `#!/usr/bin/env node` or rebuilding it via npm-on-nix.
+      # Git worktree manager (phantompane/phantom). Not in nixpkgs.
+      # brew pulls node in automatically as a dep, so phantom and the
+      # brew bottle's node end up coexisting alongside the nix node.
       "phantom"
     ];
 


### PR DESCRIPTION
## Summary

Two factual corrections to the documentation about `phantom`.

1. **What it is**: I described it as "cmux's shell completion CLI" throughout the migration. It is actually [`phantompane/phantom`](https://github.com/phantompane/phantom) — a CLI tool for managing Git worktrees in parallel. Two unrelated tools that both register `phantom completion zsh` -style hooks confused me.

2. **The shebang patch story**: the README and `darwin/homebrew.nix` warned that the brew bottle ships with `#!/opt/homebrew/opt/node/bin/node` and therefore needs a manual `#!/usr/bin/env node` patch after migrating Node to nix. **That patch is unnecessary in the steady state.** Verified empirically: running `brew reinstall phantom` pulls node back in as a brew dep automatically and the original shebang resolves cleanly because `/opt/homebrew/opt/node/bin/node` is restored. The patch was only relevant during the Phase 4b transition window where the user had `brew uninstall node` separately. Now that `phantom` is declared in `darwin/homebrew.nix` and `cleanup = "uninstall"` is in effect, brew keeps node as a dep of phantom and no patch is needed.

### Changes

- `darwin/homebrew.nix` — `brews` comment now reads "Not in nixpkgs. brew pulls node in automatically as a dep, so phantom and the brew bottle's node end up coexisting alongside the nix node." (down from the previous shebang explanation).
- `README.md`
  - Brew formulae table row: `phantom only ([Git worktree manager](https://github.com/phantompane/phantom); not in nixpkgs)`.
  - The `**phantom shebang**` caveat under Caveats is **removed entirely** — the original wording was about the manual patch, which no longer applies.

`CLAUDE.md` was not affected because its caveat described phantom only by its shebang behaviour without claiming what phantom is.

## Note on push path

The local `git push` from this session is hitting HTTP 503 from the sandbox proxy (probably related to the recent `MihiroH` → `mihirove` GitHub username rename). The branch and the two commits (`92ab342` for the original phantom-name fix, `aaa79bd` for the broader patch-claim removal in this revision) were created via the GitHub MCP `push_files` API. Functionally identical to a normal push.

## Test plan

This is documentation only.

- [ ] `git diff master..claude/fix-phantom-doc` shows only `darwin/homebrew.nix` and `README.md`.
- [ ] On the actual Mac, `head -1 $(which phantom)` after a fresh `brew reinstall phantom` returns `#!/opt/homebrew/opt/node/bin/node` (already verified) and the binary still runs because brew also reinstalled its `node` dep at that exact path.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2