### PR TITLE
feat(nix): Phase 8 — multi-host (mac, mac-mini), Determinate-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ Guidance for Claude Code (claude.ai/code) working in this repository.
 
 ## Repository overview
 
-Declarative macOS dotfiles. The whole environment — shell, editor, terminals, fonts, GUI apps, language runtimes, GPG agent, Tailscale — is described by a Nix flake and applied with `nix-darwin` + `home-manager`. One `darwin-rebuild switch` is the only command needed to converge to the declared state.
+Declarative macOS dotfiles. The whole environment — shell, editor, terminals, fonts, GUI apps, language runtimes, GPG agent, Tailscale — is described by a Nix flake and applied with `nix-darwin` + `home-manager`. One `nix run .#switch` is the only command needed to converge to the declared state.
+
+`flake.nix` declares one host per machine via the `hosts` attrset. The `nix run .#switch` wrapper picks the matching `darwinConfigurations.<host>` from the current `LocalHostName`; override with `DARWIN_HOST=<host>` when bootstrapping. Hosts can opt into Determinate Nix (which manages its own daemon) by setting `determinate = true;`; that flag flips `darwin/nix.nix` so the conflicting `nix.*` options become no-ops.
 
 ## Build / verify / activate
 
@@ -23,10 +25,10 @@ nix run .#update
 
 # Roll back
 darwin-rebuild --list-generations
-sudo darwin-rebuild switch --flake .#mihiro-mac~1
+sudo darwin-rebuild switch --flake .#mac~1   # or .#mac-mini~1 etc.
 ```
 
-`nix run .#switch` wraps `darwin-rebuild switch --flake .#mihiro-mac` — the rebuild binary it invokes is the one built from this flake's pinned `nix-darwin` input, so no GitHub round-trip per activation.
+`nix run .#switch` wraps `darwin-rebuild switch --flake .#<host>` — `<host>` is read from `scutil --get LocalHostName` (or the `DARWIN_HOST` env var). The rebuild binary it invokes is built from this flake's pinned `nix-darwin` input, so no GitHub round-trip per activation.
 
 ## Architecture
 
@@ -35,7 +37,7 @@ flake.nix                    # inputs: nixpkgs (unstable), nix-darwin, home-mana
 └── lib/mkHost.nix           # darwinSystem factory; passes inputs/hostName/system/username/dotfilesPath as specialArgs
     ├── darwin/              # system-level (root)
     │   ├── default.nix      # imports + networking.hostName + nixpkgs config
-    │   ├── nix.nix          # experimental-features, gc, trusted-users
+    │   ├── nix.nix          # nix.* settings (no-op when host is Determinate)
     │   ├── system.nix       # system.stateVersion, primaryUser
     │   ├── users.nix        # users.users.<name>, login shell
     │   ├── homebrew.nix     # casks + brews + cleanup="uninstall"
@@ -114,4 +116,5 @@ nix run .#switch                # apply
 - **macOS App Management permission**: first activation touching `~/Applications/Home Manager Apps/` requires the active terminal to be granted "App Management" in System Settings → Privacy & Security.
 - **Karabiner**: needs Full Disk Access on `karabiner_grabber` and `karabiner_observer` (System Settings → Privacy & Security).
 - **iTerm2 plist**: `home/programs/iterm2.nix` runs `defaults import` and `killall cfprefsd` so the imported plist actually takes effect; running iTerm2 windows may need to be relaunched.
-- **`phantom` shebang**: the binary's `#!/opt/homebrew/opt/node/bin/node` shebang gets patched in place to `#!/usr/bin/env node` so it can use the nix-managed Node. `brew reinstall phantom` would reset the patch.
+- **Determinate Nix vs `nix.enable`**: hosts marked `determinate = true` in the flake's `hosts` attrset get `nix.enable = false` and the `nix.gc` / `nix.settings` / `nix.optimise` options are inert — Determinate manages the daemon itself.
+- **`DARWIN_HOST` override**: a brand-new machine's `LocalHostName` is the macOS default (e.g. `Mihiros-Mac-mini`). Pass `DARWIN_HOST=<flake-host>` for the first activation; the switch sets `LocalHostName` and subsequent runs auto-detect.

--- a/README.md
+++ b/README.md
@@ -7,21 +7,49 @@
 
 Declarative macOS dotfiles managed with [Nix flakes](https://nixos.wiki/wiki/Flakes), [nix-darwin](https://github.com/LnL7/nix-darwin) and [home-manager](https://github.com/nix-community/home-manager). One `nix run .#switch` rebuilds the system: shell, editor, terminals, fonts, GUI apps, language runtimes, GPG agent, Tailscale, all at once and pinned by `flake.lock`.
 
+## Hosts
+
+`flake.nix` declares one entry per machine. Both run [official Nix](https://nixos.org/download) so that nix-darwin can manage the daemon, GC, and `/etc/nix/nix.conf` consistently. The `determinate = true` opt-in is wired through `lib/mkHost.nix` for future hosts that prefer [Determinate Nix](https://install.determinate.systems/).
+
+| Host | Nix installer | `nix.enable` |
+|---|---|---|
+| `mac` | official | `true` |
+| `mac-mini` | official | `true` |
+
+`nix run .#switch` reads the current `LocalHostName` (`scutil --get LocalHostName`) and applies the matching `darwinConfigurations.<host>`. Override with the `DARWIN_HOST` env var when bootstrapping a fresh machine whose hostname has not been set yet.
+
 ## Quick start (fresh Mac)
 
 ```bash
-# 1. Install Nix (Determinate Systems installer enables flakes by default)
-curl -fsSL https://install.determinate.systems/nix | sh -s -- install
+# 1. Install official Nix (multi-user). Same installer for every host.
+sh <(curl -L https://nixos.org/nix/install) --daemon
 
-# 2. Clone this repo
+# 2. Enable flakes for the bootstrap shell only — the system-level
+#    /etc/nix/nix.conf is set declaratively by darwin/nix.nix on the
+#    very next switch.
+mkdir -p ~/.config/nix
+echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+
+# 3. Clone this repo
 git clone git@github.com:mihirove/dotfiles.git ~/Documents/personal/dotfiles
 cd ~/Documents/personal/dotfiles
 
-# 3. Activate (works for both first-time bootstrap and every subsequent rebuild)
-nix run .#switch
+# 4. Activate. The host's flake entry is picked from the current
+#    LocalHostName; on a fresh machine override it once until the
+#    nix-darwin activation sets the hostname for you.
+DARWIN_HOST=mac-mini nix run .#switch    # first-time bootstrap
+nix run .#switch                         # subsequent rebuilds
 ```
 
-The host configuration is `darwinConfigurations."mihiro-mac"` (Apple Silicon). To target a different machine, edit `hostName` / `system` / `username` at the top of `flake.nix`.
+To add a new host, edit the `hosts` attrset at the top of `flake.nix`:
+
+```nix
+hosts = {
+  mac      = { determinate = false; };
+  mac-mini = { determinate = false; };
+  new-host = { determinate = false; };
+};
+```
 
 ## Daily commands
 
@@ -32,7 +60,7 @@ nix run .#update     # nix flake update
 nix flake check      # type-check all options
 ```
 
-These wrap the underlying `darwin-rebuild` and `nix flake` invocations so the host name (`.#mihiro-mac`) does not have to be retyped.
+These wrap the underlying `darwin-rebuild` and `nix flake` invocations so the host name does not have to be retyped.
 
 ## Repository layout
 
@@ -41,11 +69,11 @@ dotfiles/
 ├── flake.nix              # inputs (nixpkgs, nix-darwin, home-manager) + outputs (darwinConfigurations + apps)
 ├── flake.lock
 ├── lib/
-│   └── mkHost.nix         # darwinSystem factory; passes specialArgs (incl. dotfilesPath)
+│   └── mkHost.nix         # darwinSystem factory; passes specialArgs (incl. dotfilesPath, determinate)
 │
 ├── darwin/                # nix-darwin (system-level, root-managed)
 │   ├── default.nix        # imports the rest, sets hostName + nixpkgs.hostPlatform
-│   ├── nix.nix            # experimental-features, gc, trusted-users
+│   ├── nix.nix            # nix.* settings (no-op when determinate = true)
 │   ├── system.nix         # system.stateVersion, primaryUser, defaults
 │   ├── users.nix          # users.users.<name>, login shell
 │   ├── homebrew.nix       # cask + brew formula declarations
@@ -118,8 +146,8 @@ Edit the `casks = [ ... ]` list in `darwin/homebrew.nix`. Removing a line uninst
 `darwin-rebuild` keeps the last few generations:
 
 ```bash
-sudo darwin-rebuild --list-generations
-sudo darwin-rebuild switch --flake .#mihiro-mac~1   # previous generation
+darwin-rebuild --list-generations
+sudo darwin-rebuild switch --flake .#mac~1   # previous generation on the `mac` host
 ```
 
 ## Secrets
@@ -139,7 +167,8 @@ export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/legacy_credentials/<
 
 - **macOS App Management permission**: the first activation that touches `~/Applications/Home Manager Apps/` (kitty / Maccy via nix) requires you to grant the active terminal "App Management" in System Settings → Privacy & Security.
 - **Tailscale state**: `services.tailscale.enable` keeps the auth state at `/Library/Tailscale/tailscaled.state`. Migrating from the brew formula adopts that path automatically — no re-login required.
-- **Non-Determinate Nix installers**: official `https://nixos.org/download` does not enable flakes by default. If you used the official installer, prepend `--extra-experimental-features 'nix-command flakes'` to the first `nix run .#switch`, or add `experimental-features = nix-command flakes` to `~/.config/nix/nix.conf`.
+- **Determinate Nix opt-in**: a host can flip to [Determinate Nix](https://install.determinate.systems/) by setting `determinate = true;` in the `hosts` attrset. That makes `darwin/nix.nix` set `nix.enable = false` and skips the `nix.gc` / `nix.settings` / `nix.optimise` options because Determinate manages its own daemon. None of today's hosts use this.
+- **`DARWIN_HOST` override**: on a brand-new machine, `LocalHostName` reflects the macOS default (e.g. `Mihiros-Mac-mini`), not the flake-side host name. Pass `DARWIN_HOST=<flake-host>` for the first activation; the switch sets `LocalHostName` and subsequent runs auto-detect.
 
 ## License
 

--- a/darwin/nix.nix
+++ b/darwin/nix.nix
@@ -1,19 +1,20 @@
-{ lib, username, ... }:
+{ lib, username, determinate, ... }:
 
 {
-  nix.settings = {
+  # Determinate Nix manages the daemon itself, so nix-darwin must yield
+  # ownership and skip the nix.* settings below — they would conflict.
+  nix.enable = !determinate;
+
+  nix.settings = lib.mkIf (!determinate) {
     experimental-features = [ "nix-command" "flakes" ];
     trusted-users = [ "root" username ];
   };
 
-  nix.gc = {
+  nix.gc = lib.mkIf (!determinate) {
     automatic = true;
     interval = [{ Weekday = 0; Hour = 3; Minute = 0; }];
     options = "--delete-older-than 30d";
   };
 
-  nix.optimise.automatic = true;
-
-  # Set to false if using Determinate Nix (which manages the daemon itself).
-  nix.enable = lib.mkDefault true;
+  nix.optimise.automatic = lib.mkIf (!determinate) true;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "mihiro-mac dotfiles (nix-darwin + home-manager)";
+  description = "macOS dotfiles (nix-darwin + home-manager)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -20,20 +20,20 @@
       forAllSystems = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-darwin" ];
       mkHost = import ./lib/mkHost.nix;
 
-      hostName = "mihiro-mac";
       system = "aarch64-darwin";
       pkgs = nixpkgs.legacyPackages.${system};
 
-      # Pinned via flake.lock instead of fetched from GitHub on every run,
-      # so `nix run .#switch` does not hit the unauthenticated API rate limit.
-      darwinRebuild =
-        "${self.darwinConfigurations.${hostName}.config.system.build.darwin-rebuild}/bin/darwin-rebuild";
+      hosts = {
+        mac      = { determinate = false; };
+        mac-mini = { determinate = true;  };
+      };
     in
     {
-      darwinConfigurations.${hostName} = mkHost {
+      darwinConfigurations = nixpkgs.lib.mapAttrs (hostName: hostCfg: mkHost {
         inherit inputs hostName system;
         username = "mihiro";
-      };
+        determinate = hostCfg.determinate;
+      }) hosts;
 
       formatter = forAllSystems (sys:
         nixpkgs.legacyPackages.${sys}.nixpkgs-fmt);
@@ -44,8 +44,9 @@
           meta.description = "Build the darwin system into ./result without activating";
           program = toString (pkgs.writeShellScript "darwin-build" ''
             set -e
-            echo "Building darwin configuration..."
-            nix build .#darwinConfigurations.${hostName}.system "$@"
+            HOST="''${DARWIN_HOST:-$(scutil --get LocalHostName 2>/dev/null || hostname -s)}"
+            echo "Building darwin configuration for: ''${HOST}"
+            nix build .#darwinConfigurations.''${HOST}.system "$@"
             echo "Build successful. Run 'nix run .#switch' to apply."
           '');
         };
@@ -55,7 +56,11 @@
           meta.description = "Build and activate the darwin system";
           program = toString (pkgs.writeShellScript "darwin-switch" ''
             set -eo pipefail
-            exec sudo ${darwinRebuild} switch --flake .#${hostName} "$@"
+            HOST="''${DARWIN_HOST:-$(scutil --get LocalHostName 2>/dev/null || hostname -s)}"
+            echo "Activating darwin configuration for: ''${HOST}"
+            REBUILD=$(nix build --no-link --print-out-paths \
+              .#darwinConfigurations.''${HOST}.config.system.build.darwin-rebuild)
+            exec sudo "''${REBUILD}/bin/darwin-rebuild" switch --flake .#''${HOST} "$@"
           '');
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
 
       hosts = {
         mac      = { determinate = false; };
-        mac-mini = { determinate = true;  };
+        mac-mini = { determinate = false; };
       };
     in
     {

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -1,11 +1,11 @@
-{ inputs, hostName, system, username }:
+{ inputs, hostName, system, username, determinate ? false }:
 
 let
   dotfilesPath = "/Users/${username}/Documents/personal/dotfiles";
 in
 inputs.nix-darwin.lib.darwinSystem {
   inherit system;
-  specialArgs = { inherit inputs hostName username system dotfilesPath; };
+  specialArgs = { inherit inputs hostName username system dotfilesPath determinate; };
   modules = [
     ../darwin
     inputs.home-manager.darwinModules.home-manager


### PR DESCRIPTION
## Summary

Phase 8: refactor the flake to support multiple hosts. Adds `mac` (renamed from `mihiro-mac`) and a new `mac-mini` host, both running official Nix. The `determinate` flag is wired all the way through `lib/mkHost.nix` → `darwin/nix.nix` so flipping a future host onto Determinate Nix is a one-line change, but no host uses it today.

### `flake.nix`

```nix
hosts = {
  mac      = { determinate = false; };
  mac-mini = { determinate = false; };
};

darwinConfigurations = nixpkgs.lib.mapAttrs (hostName: hostCfg: mkHost {
  inherit inputs hostName system;
  username = "mihiro";
  determinate = hostCfg.determinate;
}) hosts;
```

The `apps.<system>.{build,switch}` scripts now resolve the host at runtime instead of being baked to a single name:

```bash
HOST="${DARWIN_HOST:-$(scutil --get LocalHostName 2>/dev/null || hostname -s)}"
```

`switch` also resolves `darwin-rebuild` from the per-host pinned closure via `nix build --no-link --print-out-paths`, so each host uses its own flake-locked rebuild binary.

### `lib/mkHost.nix`

Accepts a `determinate ? false` flag and forwards it via `specialArgs`.

### `darwin/nix.nix`

```nix
nix.enable = !determinate;
nix.settings = lib.mkIf (!determinate) { ... };
nix.gc = lib.mkIf (!determinate) { ... };
nix.optimise.automatic = lib.mkIf (!determinate) true;
```

When `determinate = true`, every `nix.*` option becomes inert so Determinate Nix's daemon retains ownership.

### `README.md` / `CLAUDE.md`

- New "Hosts" section documents the `mac` / `mac-mini` table and the `DARWIN_HOST` env var override for first-time bootstrap.
- Quick start updated to use the official Nix multi-user installer + a one-line `~/.config/nix/nix.conf` to enable flakes for the bootstrap shell. After the first switch, nix-darwin owns `/etc/nix/nix.conf`.
- Caveats updated: the Determinate Nix opt-in is described as "not in use today, but a one-flag flip away".

### Note on hostnames

`darwinConfigurations.mihiro-mac` is renamed to `.mac`. The first switch on the existing Mac under this branch will rename `LocalHostName` from `mihiro-mac` to `mac`; SSH known_hosts entries, mDNS announcements, etc. tied to `mihiro-mac` will need to be regenerated.

`mac-mini` is brand-new: bootstrap that machine with `DARWIN_HOST=mac-mini nix run .#switch` once, then subsequent rebuilds auto-detect.

### Note on push path

The local `git push` from this session continues to hit HTTP 503 against the sandbox proxy (a side effect of the recent `MihiroH` → `mihirove` rename). The branch was built via two `mcp__github__push_files` commits (`a644068`, `7a3c385`); they collapse on squash merge.

## Test plan

On each Mac:

- [ ] `nix flake check` passes.
- [ ] `nix flake show` lists `darwinConfigurations.{mac,mac-mini}` and the three `apps.aarch64-darwin.*`.
- [ ] On `mac`: existing rebuild works — `nix run .#switch` (auto-detect) activates `darwinConfigurations.mac` and renames `LocalHostName` from `mihiro-mac` to `mac`.
- [ ] On `mac-mini`: fresh activate works — `DARWIN_HOST=mac-mini nix run .#switch` activates the new host config.
- [ ] After both rebuilds, `which node python3 git phantom` resolve under nix profile / brew as documented; tailscale stays up; iTerm2 / Maccy / kitty still launch from the configured paths.

https://claude.ai/code/session_01AqmxoiAziggYNgyk5SU2K2